### PR TITLE
Add monitoring to individual functions in sync

### DIFF
--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -517,6 +517,14 @@ var self = {
       });
     }
 
+    // Send number of dataset clients per sync loop.
+    var datasetId = Object.keys(self.datasets)[0];
+    var datasetClientCount = 0;
+    if(datasetId) {
+      datasetClientCount = Object.keys(self.datasets[datasetId].clients).length;
+    }
+    apiMetrics.gauge()(apiMetrics.title + '_api_client_count', {module: 'sync-DataSetModel', method:"datasetClientCount"}, datasetClientCount);
+
     for (var dataset_id in self.datasets) {
       if (self.datasets.hasOwnProperty(dataset_id)) {
         var dataset = self.datasets[dataset_id];

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var async = require('async');
-var defaultDataHandler = require('./sync-datahandler')();
+var defaultDataHandler = require('./sync-datahandler');
 var syncUtil = require('./sync-util');
 
 /**
@@ -410,7 +410,7 @@ var self = {
     var metaDataHash = syncUtil.generateHash(meta_data);
 
     var timeTaken = Date.now() - startTime;
-    self.apiMetrics.gauge()(self.apiMetrics + '_api_timing',{method:"doSyncLoop"}, timeTaken);
+    self.apiMetrics.gauge()(self.apiMetrics + '_api_timing', {method:"getClientHash"}, timeTaken);
 
     return queryParamsHash + '-' + metaDataHash;
   },
@@ -630,7 +630,7 @@ var self = {
 
 var init = function (apiMetrics) {
 
-  defaultDataHandler = require('./sync-datahandler')(apiMetrics);
+  defaultDataHandler.setApiMetrics(apiMetrics);
 
   syncUtil.setLogger(syncUtil.SYNC_LOGGER, {logLevel: self.defaults.logLevel});
 

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var async = require('async');
-var defaultDataHandler = require('./sync-datahandler');
+var defaultDataHandler = require('./sync-datahandler')();
 var syncUtil = require('./sync-util');
 
 /**
@@ -31,6 +31,8 @@ var self = {
     return cb()
   },
 
+  apiMetrics: undefined,
+
   defaults: {
     "syncFrequency": 10,
     "clientSyncTimeout": 15,
@@ -49,6 +51,9 @@ var self = {
   },
 
   doListHandler: function (dataset_id, query_params, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doListHandler'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.listHandler) {
@@ -61,6 +66,9 @@ var self = {
   },
 
   doCreateHandler: function (dataset_id, data, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doCreateHandler'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.createHandler) {
@@ -73,6 +81,9 @@ var self = {
   },
 
   doReadHandler: function (dataset_id, uid, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doReadHandler'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.readHandler) {
@@ -85,6 +96,9 @@ var self = {
   },
 
   doUpdateHandler: function (dataset_id, uid, data, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doUpdateHandler'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.updateHandler) {
@@ -97,6 +111,9 @@ var self = {
   },
 
   doDeleteHandler: function (dataset_id, uid, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doDeleteHandler'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.deleteHandler) {
@@ -108,7 +125,7 @@ var self = {
     });
   },
 
-  doCollisionHandler: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {
+  doCollisionHandler: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {    
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.collisionHandler) {
@@ -121,6 +138,9 @@ var self = {
   },
 
   doCollisionLister: function (dataset_id, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doCollisionLister'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.collisionLister) {
@@ -133,6 +153,9 @@ var self = {
   },
 
   doCollisionRemover: function (dataset_id, hash, cb, meta_data) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doCollisionRemover'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.collisionRemover) {
@@ -145,6 +168,9 @@ var self = {
   },
 
   doRequestInterceptor: function (dataset_id, params, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doRequestInterceptor'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.requestInterceptor) {
@@ -157,6 +183,8 @@ var self = {
   },
 
   getDataset: function (dataset_id, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDataset'}, cb);
 
     // TODO - Persist data sets - in memory or more permanently ($fh.db())
     if (self.deletedDatasets[dataset_id]) {
@@ -179,6 +207,9 @@ var self = {
   },
 
   createDataset: function (dataset_id, options, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'createDataset'}, cb);
+
     syncUtil.doLog(dataset_id, 'info', 'createDataset');
     var datasetConfig = JSON.parse(JSON.stringify(self.defaults));
     if (options) {
@@ -208,6 +239,8 @@ var self = {
 
   removeDataset: function (dataset_id, cb) {
 
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'removeDataset'}, cb);
+
     // TODO - Persist data sets - in memory or more permanently ($fh.db())
     self.deletedDatasets[dataset_id] = new Date().getTime();
 
@@ -217,6 +250,9 @@ var self = {
   },
 
   stopDatasetSync: function (dataset_id, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'stopDatasetSync'}, cb);
+
     syncUtil.doLog(dataset_id, 'info', 'stopDatasetSync');
     self.getDataset(dataset_id, function (err) {
       if (err) {
@@ -227,6 +263,9 @@ var self = {
   },
 
   stopAllDatasetSync: function (cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'stopAllDatasetSync'}, cb);
+
     syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'stopAllDatasetSync');
 
     var stoppingDatasets = [];
@@ -249,6 +288,9 @@ var self = {
   },
 
   getDatasetClient: function (dataset_id, params, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDatasetClient'}, cb);
+
     // Verify that query_param have been passed
     if (!params || !params.query_params) {
       return cb("no_query_params", null);
@@ -294,6 +336,9 @@ var self = {
   },
 
   getDatasetClientRecords: function (datasetClient, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDatasetClientRecords'}, cb);
+
     var datasetClientId = datasetClient.id;
     if (typeof self.datasetClientRecords[datasetClientId] !== "undefined") {
       return cb(null, self.datasetClientRecords[datasetClientId]);
@@ -308,6 +353,9 @@ var self = {
   },
 
   createDatasetClient: function (dataset_id, query_params, meta_data, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'createDatasetClient'}, cb);
+
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
       var clientHash = dataset_id + "_" + self.getClientHash(query_params, meta_data);
@@ -334,6 +382,9 @@ var self = {
   },
 
   removeDatasetClient: function (datasetClient, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'removeDatasetClient'}, cb);
+
     if (datasetClient && datasetClient.id) {
       delete dataset.clients[datasetClient.id];
     }
@@ -341,6 +392,9 @@ var self = {
   },
 
   syncDatasetClient: function (datasetClient, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'syncDatasetClient'}, cb);
+
     datasetClient.syncPending = true;
     syncUtil.doLog(datasetClient.datasetId, 'silly', 'pushing cb to pendingCallbacks of datasetcClient id = ' + datasetClient.id, datasetClient);
     datasetClient.pendingCallbacks.push(function (err, res) {
@@ -350,13 +404,21 @@ var self = {
   },
 
   getClientHash: function (query_params, meta_data) {
+    var startTime = Date.now();
+
     var queryParamsHash = syncUtil.generateHash(query_params);
     var metaDataHash = syncUtil.generateHash(meta_data);
+
+    var timeTaken = Date.now() - startTime;
+    self.apiMetrics.gauge()(self.apiMetrics + '_api_timing',{method:"doSyncLoop"}, timeTaken);
 
     return queryParamsHash + '-' + metaDataHash;
   },
 
   doSyncList: function (dataset, datasetClient, cb) {
+
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doSyncList'}, cb);
+
     datasetClient.syncRunning = true;
     datasetClient.syncPending = false;
     datasetClient.syncLoopStart = new Date().getTime();
@@ -403,6 +465,8 @@ var self = {
 
   forceSyncList: function (dataset_id, datasetClient, cb) {
 
+    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'forceSyncList'}, cb);
+
     self.doListHandler(dataset_id, datasetClient.queryParams, function (err, records) {
       if (err) return cb(err);
 
@@ -429,7 +493,8 @@ var self = {
   },
 
   doSyncLoop: function (apiMetrics) {
-    var start = Date.now();
+    var doSyncLoopStart = Date.now();
+
     var syncList=function (datasetClient) {
       self.doSyncList(dataset, datasetClient, function (err, res) {
         // Check if there are aby pending callbacks for this sync Client;
@@ -498,8 +563,8 @@ var self = {
         }
       }
     }
-    var timeTaken = Date.now() - start;
-    apiMetrics.gauge()(apiMetrics + '_api_timing',{method:"doSyncLoop"}, timeTaken);
+    var doSyncLoopTimeTaken = Date.now() - doSyncLoopStart;
+    apiMetrics.gauge()(apiMetrics.title + '_api_timing', {module: 'sync-DataSetModel', method:"doSyncLoop"}, doSyncLoopTimeTaken);
   },
 
   setDefaultHandlers: function () {
@@ -564,9 +629,14 @@ var self = {
 };
 
 var init = function (apiMetrics) {
+
+  defaultDataHandler = require('./sync-datahandler')(apiMetrics);
+
   syncUtil.setLogger(syncUtil.SYNC_LOGGER, {logLevel: self.defaults.logLevel});
 
   syncUtil.doLog(syncUtil.SYNC_LOGGER, 'verbose', 'DataSetModel Init');
+
+  self.apiMetrics = apiMetrics;
 
   self.setDefaultHandlers();
 

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -169,7 +169,7 @@ var self = {
 
   doRequestInterceptor: function (dataset_id, params, cb) {
 
-    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doRequestInterceptor'}, cb);
+    //var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'doRequestInterceptor'}, cb);
 
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
@@ -184,7 +184,7 @@ var self = {
 
   getDataset: function (dataset_id, cb) {
 
-    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDataset'}, cb);
+    //var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDataset'}, cb);
 
     // TODO - Persist data sets - in memory or more permanently ($fh.db())
     if (self.deletedDatasets[dataset_id]) {
@@ -208,7 +208,7 @@ var self = {
 
   createDataset: function (dataset_id, options, cb) {
 
-    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'createDataset'}, cb);
+    //var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'createDataset'}, cb);
 
     syncUtil.doLog(dataset_id, 'info', 'createDataset');
     var datasetConfig = JSON.parse(JSON.stringify(self.defaults));
@@ -289,7 +289,7 @@ var self = {
 
   getDatasetClient: function (dataset_id, params, cb) {
 
-    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDatasetClient'}, cb);
+    //var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'getDatasetClient'}, cb);
 
     // Verify that query_param have been passed
     if (!params || !params.query_params) {
@@ -354,7 +354,7 @@ var self = {
 
   createDatasetClient: function (dataset_id, query_params, meta_data, cb) {
 
-    var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'createDatasetClient'}, cb);
+    //var cb = self.apiMetrics.getTimedCallback({module: 'sync-DataSetModel', method: 'createDatasetClient'}, cb);
 
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
@@ -493,7 +493,7 @@ var self = {
   },
 
   doSyncLoop: function (apiMetrics) {
-    var doSyncLoopStart = Date.now();
+    //var doSyncLoopStart = Date.now();
 
     var syncList=function (datasetClient) {
       self.doSyncList(dataset, datasetClient, function (err, res) {
@@ -563,8 +563,8 @@ var self = {
         }
       }
     }
-    var doSyncLoopTimeTaken = Date.now() - doSyncLoopStart;
-    apiMetrics.gauge()(apiMetrics.title + '_api_timing', {module: 'sync-DataSetModel', method:"doSyncLoop"}, doSyncLoopTimeTaken);
+    //var doSyncLoopTimeTaken = Date.now() - doSyncLoopStart;
+    //apiMetrics.gauge()(apiMetrics.title + '_api_timing', {module: 'sync-DataSetModel', method:"doSyncLoop"}, doSyncLoopTimeTaken);
   },
 
   setDefaultHandlers: function () {

--- a/lib/sync-datahandler.js
+++ b/lib/sync-datahandler.js
@@ -3,151 +3,173 @@ var util = require('util');
 var _ = require('underscore');
 var fhdb;
 
-module.exports = {
+module.exports = function(apiMetrics){
+ return {
+    setFHDB: function (db) {
+      fhdb = db;
+    },
 
-  setFHDB: function (db) {
-    fhdb = db;
-  },
+    doList: function (dataset_id, params, cb, meta_data) {
 
-  doList: function (dataset_id, params, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'doList : ' + dataset_id + ' :: query_params=' + util.inspect(params) + ' :: meta_data=' + util.inspect(meta_data));
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doList'}, cb);
+
+      syncUtil.doLog(dataset_id, 'verbose', 'doList : ' + dataset_id + ' :: query_params=' + util.inspect(params) + ' :: meta_data=' + util.inspect(meta_data));
 
 
-    var dbQuery = {};
-    _.extend(dbQuery, params, {
-      "act": "list",
-      "type": dataset_id
-    });
+      var dbQuery = {};
+      _.extend(dbQuery, params, {
+        "act": "list",
+        "type": dataset_id
+      });
 
-    fhdb(dbQuery, function (err, res) {
-      if (err) return cb(err);
+      fhdb(dbQuery, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doListQuery'}, function (err, res) {
+        if (err) return cb(err);
 
-      var resJson = {};
-      if (res.hasOwnProperty('list')) {
-        for (var di = 0, dl = res.list.length; di < dl; di += 1) {
-          resJson[res.list[di].guid] = res.list[di].fields;
+        var resJson = {};
+        if (res.hasOwnProperty('list')) {
+          for (var di = 0, dl = res.list.length; di < dl; di += 1) {
+            resJson[res.list[di].guid] = res.list[di].fields;
+          }
         }
-      }
-      else {
-        syncUtil.doLog('list property not returned in response from fhdb.');
-      }
-      return cb(null, resJson);
-    });
-  },
+        else {
+          syncUtil.doLog('list property not returned in response from fhdb.');
+        }
+        return cb(null, resJson);
+      }));
+    },
 
-  doCreate: function (dataset_id, data, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
+    doCreate: function (dataset_id, data, cb, meta_data) {
 
-    fhdb({
-      "act": "create",
-      "type": dataset_id,
-      "fields": data
-    }, function (err, res) {
-      if (err) return cb(err);
-      var data = {'uid': res.guid, 'data': res.fields};
-      return cb(null, data);
-    });
-  },
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreate'}, cb);
 
-  doRead: function (dataset_id, uid, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'doRead : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
+      syncUtil.doLog(dataset_id, 'verbose', 'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
 
-    fhdb({
-      "act": "read",
-      "type": dataset_id,
-      "guid": uid
-    }, function (err, res) {
-      if (err) return cb(err);
-      return cb(null, res.fields);
-    });
-  },
+      fhdb({
+        "act": "create",
+        "type": dataset_id,
+        "fields": data
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreateQuery'}, function (err, res) {
+        if (err) return cb(err);
+        var data = {'uid': res.guid, 'data': res.fields};
+        return cb(null, data);
+      }));
+    },
 
-  doUpdate: function (dataset_id, uid, data, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'doUpdate : ' + dataset_id + ' :: ' + uid + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
+    doRead: function (dataset_id, uid, cb, meta_data) {
 
-    fhdb({
-      "act": "update",
-      "type": dataset_id,
-      "guid": uid,
-      "fields": data
-    }, function (err, res) {
-      if (err) return cb(err);
-      return cb(null, res.fields);
-    });
-  },
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doRead'}, cb);
 
-  doDelete: function (dataset_id, uid, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'doDelete : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
+      syncUtil.doLog(dataset_id, 'verbose', 'doRead : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
 
-    fhdb({
-      "act": "delete",
-      "type": dataset_id,
-      "guid": uid
-    }, function (err, res) {
-      if (err) return cb(err);
-      return cb(null, res.fields);
-    });
-  },
+      fhdb({
+        "act": "read",
+        "type": dataset_id,
+        "guid": uid
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doReadQuery'}, function (err, res) {
+        if (err) return cb(err);
+        return cb(null, res.fields);
+      }));
+    },
 
-  doCollision: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'doCollision : ' + dataset_id + ' :: hash=' + hash + ' :: timestamp=' + timestamp + ' :: uid=' + uid + ' :: pre=' + util.inspect(pre) + ' :: post=' + util.inspect(post) + ' :: meta=' + util.inspect(meta_data));
+    doUpdate: function (dataset_id, uid, data, cb, meta_data) {
 
-    var fields = {
-      "hash": hash,
-      "timestamp": timestamp,
-      "uid": uid,
-      "pre": pre,
-      "post": post
-    };
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdate'}, cb);
 
-    fhdb({
-      "act": "create",
-      "type": dataset_id + '_collision',
-      "fields": fields
-    }, function (err) {
-      if (err) console.log(err);
-    });
-  },
+      syncUtil.doLog(dataset_id, 'verbose', 'doUpdate : ' + dataset_id + ' :: ' + uid + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
 
-  listCollisions: function (dataset_id, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'listCollisions : ' + dataset_id + ' :: meta=' + util.inspect(meta_data));
-    fhdb({
-      "act": "list",
-      "type": dataset_id + '_collision'
-    }, function (err, res) {
-      if (err) return cb(err);
+      fhdb({
+        "act": "update",
+        "type": dataset_id,
+        "guid": uid,
+        "fields": data
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdateQuery'}, function (err, res) {
+        if (err) return cb(err);
+        return cb(null, res.fields);
+      }));
+    },
 
-      var resJson = {};
+    doDelete: function (dataset_id, uid, cb, meta_data) {
 
-      for (var di = 0; di < res.list.length; di++) {
-        resJson[res.list[di].fields.hash] = res.list[di].fields;
-      }
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDelete'}, cb);
 
-      cb(null, resJson);
-    });
-  },
+      syncUtil.doLog(dataset_id, 'verbose', 'doDelete : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
 
-  removeCollision: function (dataset_id, hash, cb, meta_data) {
-    syncUtil.doLog(dataset_id, 'verbose', 'removeCollision : ' + dataset_id + ' :: hash=' + hash + ' :: meta=' + util.inspect(meta_data));
-    fhdb({
-      "act": "list",
-      "type": dataset_id + '_collision',
-      "eq": {
-        "hash": hash
-      }
-    }, function (err, data) {
-      if (err) cb(err);
+      fhdb({
+        "act": "delete",
+        "type": dataset_id,
+        "guid": uid
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDeleteQuery'}, function (err, res) {
+        if (err) return cb(err);
+        return cb(null, res.fields);
+      }));
+    },
 
-      if (data.list && data.list.length === 1) {
-        var guid = data.list[0].guid;
-        fhdb({
-          "act": "delete",
-          "type": dataset_id + '_collision',
-          "guid": guid
-        }, cb);
-      } else {
-        return cb(null, {"status": "ok", "message": "No collision found for hash " + hash});
-      }
-    });
+    doCollision: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {      
+      syncUtil.doLog(dataset_id, 'verbose', 'doCollision : ' + dataset_id + ' :: hash=' + hash + ' :: timestamp=' + timestamp + ' :: uid=' + uid + ' :: pre=' + util.inspect(pre) + ' :: post=' + util.inspect(post) + ' :: meta=' + util.inspect(meta_data));
+
+      var fields = {
+        "hash": hash,
+        "timestamp": timestamp,
+        "uid": uid,
+        "pre": pre,
+        "post": post
+      };
+
+      fhdb({
+        "act": "create",
+        "type": dataset_id + '_collision',
+        "fields": fields
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCollisionQuery'}, function (err) {
+        if (err) console.log(err);
+      }));
+    },
+
+    listCollisions: function (dataset_id, cb, meta_data) {
+
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisions'}, cb);
+
+      syncUtil.doLog(dataset_id, 'verbose', 'listCollisions : ' + dataset_id + ' :: meta=' + util.inspect(meta_data));
+      fhdb({
+        "act": "list",
+        "type": dataset_id + '_collision'
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisionsQuery'}, function (err, res) {
+        if (err) return cb(err);
+
+        var resJson = {};
+
+        for (var di = 0; di < res.list.length; di++) {
+          resJson[res.list[di].fields.hash] = res.list[di].fields;
+        }
+
+        cb(null, resJson);
+      }));
+    },
+
+    removeCollision: function (dataset_id, hash, cb, meta_data) {
+      
+      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollision'}, cb);
+
+      syncUtil.doLog(dataset_id, 'verbose', 'removeCollision : ' + dataset_id + ' :: hash=' + hash + ' :: meta=' + util.inspect(meta_data));
+      fhdb({
+        "act": "list",
+        "type": dataset_id + '_collision',
+        "eq": {
+          "hash": hash
+        }
+      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollisionQuery'}, function (err, data) {
+        if (err) cb(err);
+
+        if (data.list && data.list.length === 1) {
+          var guid = data.list[0].guid;
+          fhdb({
+            "act": "delete",
+            "type": dataset_id + '_collision',
+            "guid": guid
+          }, cb);
+        } else {
+          return cb(null, {"status": "ok", "message": "No collision found for hash " + hash});
+        }
+      }));
+    }
   }
 };

--- a/lib/sync-datahandler.js
+++ b/lib/sync-datahandler.js
@@ -3,173 +3,177 @@ var util = require('util');
 var _ = require('underscore');
 var fhdb;
 
-module.exports = function(apiMetrics){
- return {
-    setFHDB: function (db) {
-      fhdb = db;
-    },
+var apiMetrics = undefined;
 
-    doList: function (dataset_id, params, cb, meta_data) {
+module.exports = {
+  setFHDB: function (db) {
+    fhdb = db;
+  },
 
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doList'}, cb);
+  setApiMetrics: function(newApiMetrics) {
+    apiMetrics = newApiMetrics;
+  },
 
-      syncUtil.doLog(dataset_id, 'verbose', 'doList : ' + dataset_id + ' :: query_params=' + util.inspect(params) + ' :: meta_data=' + util.inspect(meta_data));
+  doList: function (dataset_id, params, cb, meta_data) {
+
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doList'}, cb);
+
+    syncUtil.doLog(dataset_id, 'verbose', 'doList : ' + dataset_id + ' :: query_params=' + util.inspect(params) + ' :: meta_data=' + util.inspect(meta_data));
 
 
-      var dbQuery = {};
-      _.extend(dbQuery, params, {
-        "act": "list",
-        "type": dataset_id
-      });
+    var dbQuery = {};
+    _.extend(dbQuery, params, {
+      "act": "list",
+      "type": dataset_id
+    });
 
-      fhdb(dbQuery, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doListQuery'}, function (err, res) {
-        if (err) return cb(err);
+    fhdb(dbQuery, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doListQuery'}, function (err, res) {
+      if (err) return cb(err);
 
-        var resJson = {};
-        if (res.hasOwnProperty('list')) {
-          for (var di = 0, dl = res.list.length; di < dl; di += 1) {
-            resJson[res.list[di].guid] = res.list[di].fields;
-          }
+      var resJson = {};
+      if (res.hasOwnProperty('list')) {
+        for (var di = 0, dl = res.list.length; di < dl; di += 1) {
+          resJson[res.list[di].guid] = res.list[di].fields;
         }
-        else {
-          syncUtil.doLog('list property not returned in response from fhdb.');
-        }
-        return cb(null, resJson);
-      }));
-    },
+      }
+      else {
+        syncUtil.doLog('list property not returned in response from fhdb.');
+      }
+      return cb(null, resJson);
+    }));
+  },
 
-    doCreate: function (dataset_id, data, cb, meta_data) {
+  doCreate: function (dataset_id, data, cb, meta_data) {
 
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreate'}, cb);
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreate'}, cb);
 
-      syncUtil.doLog(dataset_id, 'verbose', 'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
+    syncUtil.doLog(dataset_id, 'verbose', 'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
 
-      fhdb({
-        "act": "create",
-        "type": dataset_id,
-        "fields": data
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreateQuery'}, function (err, res) {
-        if (err) return cb(err);
-        var data = {'uid': res.guid, 'data': res.fields};
-        return cb(null, data);
-      }));
-    },
+    fhdb({
+      "act": "create",
+      "type": dataset_id,
+      "fields": data
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreateQuery'}, function (err, res) {
+      if (err) return cb(err);
+      var data = {'uid': res.guid, 'data': res.fields};
+      return cb(null, data);
+    }));
+  },
 
-    doRead: function (dataset_id, uid, cb, meta_data) {
+  doRead: function (dataset_id, uid, cb, meta_data) {
 
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doRead'}, cb);
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doRead'}, cb);
 
-      syncUtil.doLog(dataset_id, 'verbose', 'doRead : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
+    syncUtil.doLog(dataset_id, 'verbose', 'doRead : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
 
-      fhdb({
-        "act": "read",
-        "type": dataset_id,
-        "guid": uid
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doReadQuery'}, function (err, res) {
-        if (err) return cb(err);
-        return cb(null, res.fields);
-      }));
-    },
+    fhdb({
+      "act": "read",
+      "type": dataset_id,
+      "guid": uid
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doReadQuery'}, function (err, res) {
+      if (err) return cb(err);
+      return cb(null, res.fields);
+    }));
+  },
 
-    doUpdate: function (dataset_id, uid, data, cb, meta_data) {
+  doUpdate: function (dataset_id, uid, data, cb, meta_data) {
 
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdate'}, cb);
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdate'}, cb);
 
-      syncUtil.doLog(dataset_id, 'verbose', 'doUpdate : ' + dataset_id + ' :: ' + uid + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
+    syncUtil.doLog(dataset_id, 'verbose', 'doUpdate : ' + dataset_id + ' :: ' + uid + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
 
-      fhdb({
-        "act": "update",
-        "type": dataset_id,
-        "guid": uid,
-        "fields": data
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdateQuery'}, function (err, res) {
-        if (err) return cb(err);
-        return cb(null, res.fields);
-      }));
-    },
+    fhdb({
+      "act": "update",
+      "type": dataset_id,
+      "guid": uid,
+      "fields": data
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdateQuery'}, function (err, res) {
+      if (err) return cb(err);
+      return cb(null, res.fields);
+    }));
+  },
 
-    doDelete: function (dataset_id, uid, cb, meta_data) {
+  doDelete: function (dataset_id, uid, cb, meta_data) {
 
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDelete'}, cb);
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDelete'}, cb);
 
-      syncUtil.doLog(dataset_id, 'verbose', 'doDelete : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
+    syncUtil.doLog(dataset_id, 'verbose', 'doDelete : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
 
-      fhdb({
-        "act": "delete",
-        "type": dataset_id,
-        "guid": uid
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDeleteQuery'}, function (err, res) {
-        if (err) return cb(err);
-        return cb(null, res.fields);
-      }));
-    },
+    fhdb({
+      "act": "delete",
+      "type": dataset_id,
+      "guid": uid
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDeleteQuery'}, function (err, res) {
+      if (err) return cb(err);
+      return cb(null, res.fields);
+    }));
+  },
 
-    doCollision: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {      
-      syncUtil.doLog(dataset_id, 'verbose', 'doCollision : ' + dataset_id + ' :: hash=' + hash + ' :: timestamp=' + timestamp + ' :: uid=' + uid + ' :: pre=' + util.inspect(pre) + ' :: post=' + util.inspect(post) + ' :: meta=' + util.inspect(meta_data));
+  doCollision: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {      
+    syncUtil.doLog(dataset_id, 'verbose', 'doCollision : ' + dataset_id + ' :: hash=' + hash + ' :: timestamp=' + timestamp + ' :: uid=' + uid + ' :: pre=' + util.inspect(pre) + ' :: post=' + util.inspect(post) + ' :: meta=' + util.inspect(meta_data));
 
-      var fields = {
-        "hash": hash,
-        "timestamp": timestamp,
-        "uid": uid,
-        "pre": pre,
-        "post": post
-      };
+    var fields = {
+      "hash": hash,
+      "timestamp": timestamp,
+      "uid": uid,
+      "pre": pre,
+      "post": post
+    };
 
-      fhdb({
-        "act": "create",
-        "type": dataset_id + '_collision',
-        "fields": fields
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCollisionQuery'}, function (err) {
-        if (err) console.log(err);
-      }));
-    },
+    fhdb({
+      "act": "create",
+      "type": dataset_id + '_collision',
+      "fields": fields
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCollisionQuery'}, function (err) {
+      if (err) console.log(err);
+    }));
+  },
 
-    listCollisions: function (dataset_id, cb, meta_data) {
+  listCollisions: function (dataset_id, cb, meta_data) {
 
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisions'}, cb);
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisions'}, cb);
 
-      syncUtil.doLog(dataset_id, 'verbose', 'listCollisions : ' + dataset_id + ' :: meta=' + util.inspect(meta_data));
-      fhdb({
-        "act": "list",
-        "type": dataset_id + '_collision'
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisionsQuery'}, function (err, res) {
-        if (err) return cb(err);
+    syncUtil.doLog(dataset_id, 'verbose', 'listCollisions : ' + dataset_id + ' :: meta=' + util.inspect(meta_data));
+    fhdb({
+      "act": "list",
+      "type": dataset_id + '_collision'
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisionsQuery'}, function (err, res) {
+      if (err) return cb(err);
 
-        var resJson = {};
+      var resJson = {};
 
-        for (var di = 0; di < res.list.length; di++) {
-          resJson[res.list[di].fields.hash] = res.list[di].fields;
-        }
+      for (var di = 0; di < res.list.length; di++) {
+        resJson[res.list[di].fields.hash] = res.list[di].fields;
+      }
 
-        cb(null, resJson);
-      }));
-    },
+      cb(null, resJson);
+    }));
+  },
 
-    removeCollision: function (dataset_id, hash, cb, meta_data) {
-      
-      var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollision'}, cb);
+  removeCollision: function (dataset_id, hash, cb, meta_data) {
+    
+    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollision'}, cb);
 
-      syncUtil.doLog(dataset_id, 'verbose', 'removeCollision : ' + dataset_id + ' :: hash=' + hash + ' :: meta=' + util.inspect(meta_data));
-      fhdb({
-        "act": "list",
-        "type": dataset_id + '_collision',
-        "eq": {
-          "hash": hash
-        }
-      }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollisionQuery'}, function (err, data) {
-        if (err) cb(err);
+    syncUtil.doLog(dataset_id, 'verbose', 'removeCollision : ' + dataset_id + ' :: hash=' + hash + ' :: meta=' + util.inspect(meta_data));
+    fhdb({
+      "act": "list",
+      "type": dataset_id + '_collision',
+      "eq": {
+        "hash": hash
+      }
+    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollisionQuery'}, function (err, data) {
+      if (err) cb(err);
 
-        if (data.list && data.list.length === 1) {
-          var guid = data.list[0].guid;
-          fhdb({
-            "act": "delete",
-            "type": dataset_id + '_collision',
-            "guid": guid
-          }, cb);
-        } else {
-          return cb(null, {"status": "ok", "message": "No collision found for hash " + hash});
-        }
-      }));
-    }
+      if (data.list && data.list.length === 1) {
+        var guid = data.list[0].guid;
+        fhdb({
+          "act": "delete",
+          "type": dataset_id + '_collision',
+          "guid": guid
+        }, cb);
+      } else {
+        return cb(null, {"status": "ok", "message": "No collision found for hash " + hash});
+      }
+    }));
   }
-};
+}

--- a/lib/sync-datahandler.js
+++ b/lib/sync-datahandler.js
@@ -16,7 +16,7 @@ module.exports = {
 
   doList: function (dataset_id, params, cb, meta_data) {
 
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doList'}, cb);
+    // var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doList'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'doList : ' + dataset_id + ' :: query_params=' + util.inspect(params) + ' :: meta_data=' + util.inspect(meta_data));
 
@@ -27,7 +27,8 @@ module.exports = {
       "type": dataset_id
     });
 
-    fhdb(dbQuery, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doListQuery'}, function (err, res) {
+    fhdb(dbQuery, //apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doListQuery'}, 
+      function (err, res) {
       if (err) return cb(err);
 
       var resJson = {};
@@ -40,12 +41,12 @@ module.exports = {
         syncUtil.doLog('list property not returned in response from fhdb.');
       }
       return cb(null, resJson);
-    }));
+    })//);
   },
 
   doCreate: function (dataset_id, data, cb, meta_data) {
 
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreate'}, cb);
+    // var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreate'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
 
@@ -53,16 +54,16 @@ module.exports = {
       "act": "create",
       "type": dataset_id,
       "fields": data
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreateQuery'}, function (err, res) {
+    }, /*apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCreateQuery'}, */function (err, res) {
       if (err) return cb(err);
       var data = {'uid': res.guid, 'data': res.fields};
       return cb(null, data);
-    }));
+    })//);
   },
 
   doRead: function (dataset_id, uid, cb, meta_data) {
 
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doRead'}, cb);
+    //var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doRead'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'doRead : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
 
@@ -70,15 +71,16 @@ module.exports = {
       "act": "read",
       "type": dataset_id,
       "guid": uid
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doReadQuery'}, function (err, res) {
+    }, //apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doReadQuery'}, 
+    function (err, res) {
       if (err) return cb(err);
       return cb(null, res.fields);
-    }));
+    })//);
   },
 
   doUpdate: function (dataset_id, uid, data, cb, meta_data) {
 
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdate'}, cb);
+    //var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdate'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'doUpdate : ' + dataset_id + ' :: ' + uid + ' :: ' + util.inspect(data) + ' :: meta=' + util.inspect(meta_data));
 
@@ -87,15 +89,15 @@ module.exports = {
       "type": dataset_id,
       "guid": uid,
       "fields": data
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdateQuery'}, function (err, res) {
+    }, /*apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doUpdateQuery'},*/ function (err, res) {
       if (err) return cb(err);
       return cb(null, res.fields);
-    }));
+    })//);
   },
 
   doDelete: function (dataset_id, uid, cb, meta_data) {
 
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDelete'}, cb);
+    //var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDelete'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'doDelete : ' + dataset_id + ' :: ' + uid + ' :: meta=' + util.inspect(meta_data));
 
@@ -103,10 +105,10 @@ module.exports = {
       "act": "delete",
       "type": dataset_id,
       "guid": uid
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDeleteQuery'}, function (err, res) {
+    }, /*apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doDeleteQuery'}, */function (err, res) {
       if (err) return cb(err);
       return cb(null, res.fields);
-    }));
+    })//);
   },
 
   doCollision: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {      
@@ -124,20 +126,20 @@ module.exports = {
       "act": "create",
       "type": dataset_id + '_collision',
       "fields": fields
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCollisionQuery'}, function (err) {
+    }, /*apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'doCollisionQuery'},*/ function (err) {
       if (err) console.log(err);
-    }));
+    })//);
   },
 
   listCollisions: function (dataset_id, cb, meta_data) {
 
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisions'}, cb);
+    // var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisions'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'listCollisions : ' + dataset_id + ' :: meta=' + util.inspect(meta_data));
     fhdb({
       "act": "list",
       "type": dataset_id + '_collision'
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisionsQuery'}, function (err, res) {
+    }, /*apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'listCollisionsQuery'},*/ function (err, res) {
       if (err) return cb(err);
 
       var resJson = {};
@@ -147,12 +149,12 @@ module.exports = {
       }
 
       cb(null, resJson);
-    }));
+    })//);
   },
 
   removeCollision: function (dataset_id, hash, cb, meta_data) {
     
-    var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollision'}, cb);
+    // var cb = apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollision'}, cb);
 
     syncUtil.doLog(dataset_id, 'verbose', 'removeCollision : ' + dataset_id + ' :: hash=' + hash + ' :: meta=' + util.inspect(meta_data));
     fhdb({
@@ -161,7 +163,7 @@ module.exports = {
       "eq": {
         "hash": hash
       }
-    }, apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollisionQuery'}, function (err, data) {
+    }, /*apiMetrics.getTimedCallback({module: 'sync-datahandler', method: 'removeCollisionQuery'},*/ function (err, data) {
       if (err) cb(err);
 
       if (data.list && data.list.length === 1) {
@@ -174,6 +176,6 @@ module.exports = {
       } else {
         return cb(null, {"status": "ok", "message": "No collision found for hash " + hash});
       }
-    }));
+    })//);
   }
 }

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -226,7 +226,7 @@ function doClientSync(dataset_id, params, callback) {
 
 function processPending(dataset_id, dataset, params, cb) {
 
-  var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPending'}, cb);
+  //var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPending'}, cb);
 
   var pending = params.pending;
   var meta_data = params.meta_data;
@@ -246,7 +246,7 @@ function processPending(dataset_id, dataset, params, cb) {
 
       function addUpdate(type, action, hash, uid, msg, cb) {
 
-        var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPendingAddUpdate-SingleUpdate-ListAndCreateQuery'}, cb);
+        //var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPendingAddUpdate-SingleUpdate-ListAndCreateQuery'}, cb);
 
         var update = {
           cuid: cuid,
@@ -432,7 +432,7 @@ function returnUpdates(dataset_id, params, resIn, cb) {
 
 function acknowledgeUpdates(dataset_id, params, cb) {
 
-  var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdates'}, cb);
+  //var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdates'}, cb);
 
   var updates = params.acknowledgements;
 
@@ -441,7 +441,7 @@ function acknowledgeUpdates(dataset_id, params, cb) {
 
     async.forEachSeries(updates, function (update, itemCallback) {
 
-        var itemCallback = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdates-SingleUpdate-ListAndDeleteQuery'}, itemCallback);
+        //var itemCallback = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdates-SingleUpdate-ListAndDeleteQuery'}, itemCallback);
 
         syncUtil.doLog(dataset_id, 'verbose', 'acknowledgeUpdates :: processing update ' + util.inspect(update), params);
         fhdb({

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -163,37 +163,10 @@ function doClientSync(dataset_id, params, callback) {
       }
 
       if (datasetClient.dataHash) {
-        /**
-         * In this section we are determining whether the client and the servers
-         * dataset are in sync. If they are then we will no need to do an update,
-         * if they're not we inform the client that they are out of sync.
-         * 
-         * IGNORE: `res` will have a hash appended to it below, if it doesn't somehow it
-         * will be initialised as an empty object in returnUpdates, so we might
-         * as well initialise it here.
-         * 
-         * This section was overcomplicated, the `hash` attribute of datasetClient never
-         * exists, returning datasetHash either way will result in the same behaviour.
-         * 
-         *   * If everything doesn't match the client will update.
-         * 
-         *   * If everything does match the client will be happy.
-         */
         var hashMatch = (datasetClient.dataHash === params.dataset_hash);
-        syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hash match (' + hashMatch + ')');
 
+        syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hash match (' + hashMatch + ')');
         var res = { hash: datasetClient.dataHash };
-      
-        /*if (datasetClient.dataHash === params.dataset_hash) {
-          // There are no pending updates and the client and server are in sync.
-          syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hashes match : (' + datasetClient.dataHash + ', ' + datasetClient.dataHash);
-          res.hash = datasetClient.dataHash;
-        } else {
-          // There are no pending updates and the client and server are not in sync.
-          syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hashes do not match');  
-          res.hash = datasetClient.dataHash; 
-        }*/
-        
         returnUpdates(dataset_id, params, res, callback);
       } else {
         // There is currently no dataset here. We should get it from the backend.
@@ -442,7 +415,6 @@ function returnUpdates(dataset_id, params, resIn, cb) {
     }
 
     if (!resIn) {
-      console.log('Creating resIn');
       syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - initialising res', params);
       resIn = {};
     }

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -151,7 +151,9 @@ function doSetLogLevel(dataset_id, params, cb) {
 
 function doClientSync(dataset_id, params, callback) {
   var dataset;
-  var start = Date.now();
+
+  var callback = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'doClientSync'}, callback);
+
   function clientSyncImpl() {
 
     DataSetModel.getDatasetClient(dataset_id, params, function (err, datasetClient) {
@@ -198,8 +200,6 @@ function doClientSync(dataset_id, params, callback) {
         }
       });
     });
-    var timeTaken = Date.now() - start;
-    apiMetrics.gauge()(apiMetrics.title + '_api_timing', {method: "doClientSync"}, timeTaken);
   }
 
   DataSetModel.getDataset(dataset_id, function (err, res) {
@@ -225,6 +225,9 @@ function doClientSync(dataset_id, params, callback) {
 }
 
 function processPending(dataset_id, dataset, params, cb) {
+
+  var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPending'}, cb);
+
   var pending = params.pending;
   var meta_data = params.meta_data;
 
@@ -242,6 +245,8 @@ function processPending(dataset_id, dataset, params, cb) {
       var timestamp = pendingObj.timestamp;
 
       function addUpdate(type, action, hash, uid, msg, cb) {
+
+        var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPendingAddUpdate-SingleUpdate-ListAndCreateQuery'}, cb);
 
         var update = {
           cuid: cuid,
@@ -262,7 +267,7 @@ function processPending(dataset_id, dataset, params, cb) {
             "hash": hash,
             "uid": uid
           }
-        }, function (err, found) {
+        }, apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPendingListQuery'}, function (err, found) {
           if (err) return cb(err);
           if (found && found.list && found.list.length > 0) {
             syncUtil.doLog(dataset_id, 'info', 'Update is already recorded, ignore', update);
@@ -272,11 +277,11 @@ function processPending(dataset_id, dataset, params, cb) {
               "act": "create",
               "type": dataset_id + "-updates",
               "fields": update
-            }, function (err, res) {
+            }, apiMetrics.getTimedCallback({module: 'sync-srv', method: 'processPendingCreateQuery'}, function (err, res) {
               cb(err, res);
-            });
+            }));
           }
-        });
+        }));
       }
 
       if ("create" === action) {
@@ -378,6 +383,9 @@ function processPending(dataset_id, dataset, params, cb) {
 }
 
 function returnUpdates(dataset_id, params, resIn, cb) {
+
+  var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'returnUpdates'}, cb);
+
   //syncUtil.doLog(dataset_id, 'verbose', 'START returnUpdates', params);
   syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - existing res = ' + util.inspect(resIn), params);
   var cuid = syncUtil.getCuid(params);
@@ -387,7 +395,7 @@ function returnUpdates(dataset_id, params, resIn, cb) {
     "eq": {
       "cuid": cuid
     }
-  }, function (err, res) {
+  }, apiMetrics.getTimedCallback({module: 'sync-srv', method: 'returnUpdatesListQuery'}, function (err, res) {
     if (err) return cb(err);
 
     var updates = {};
@@ -419,10 +427,12 @@ function returnUpdates(dataset_id, params, resIn, cb) {
       syncUtil.doLog(dataset_id, 'verbose', 'returnUpdates :: ' + util.inspect(updates.hashes), params);
     }
     return cb(null, resIn);
-  });
+  }));
 }
 
 function acknowledgeUpdates(dataset_id, params, cb) {
+
+  var cb = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdates'}, cb);
 
   var updates = params.acknowledgements;
 
@@ -430,6 +440,9 @@ function acknowledgeUpdates(dataset_id, params, cb) {
     syncUtil.doLog(dataset_id, 'verbose', 'acknowledgeUpdates :: ' + util.inspect(updates), params);
 
     async.forEachSeries(updates, function (update, itemCallback) {
+
+        var itemCallback = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdates-SingleUpdate-ListAndDeleteQuery'}, itemCallback);
+
         syncUtil.doLog(dataset_id, 'verbose', 'acknowledgeUpdates :: processing update ' + util.inspect(update), params);
         fhdb({
           "act": "list",
@@ -438,7 +451,7 @@ function acknowledgeUpdates(dataset_id, params, cb) {
             "cuid": update.cuid,
             "hash": update.hash
           }
-        }, function (err, res) {
+        }, apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdatesListQuery'}, function (err, res) {
           if (err) return itemCallback(err, update);
 
           if (res && res.list && res.list.length > 0) {
@@ -448,16 +461,16 @@ function acknowledgeUpdates(dataset_id, params, cb) {
               "act": "delete",
               "type": dataset_id + "-updates",
               "guid": uid
-            }, function (err) {
+            }, apiMetrics.getTimedCallback({module: 'sync-srv', method: 'acknowledgeUpdatesDeleteQuery'}, function (err) {
               if (err) return itemCallback(err, update);
 
               return itemCallback(null, update);
-            });
+            }));
           }
           else {
             return itemCallback(null, update);
           }
-        });
+        }));
       },
       function (err) {
         if (err) {
@@ -473,7 +486,8 @@ function acknowledgeUpdates(dataset_id, params, cb) {
 
 /* Synchronise the individual records for a dataset */
 function doSyncRecords(dataset_id, params, callback) {
-  var start = Date.now();
+  var callback = apiMetrics.getTimedCallback({module: 'sync-srv', method: 'doSyncRecords'}, callback);
+
   syncUtil.doLog(dataset_id, 'verbose', 'doSyncRecords', params);
   // Verify that query_param have been passed
   if (!params || !params.query_params) {
@@ -525,8 +539,6 @@ function doSyncRecords(dataset_id, params, callback) {
       }
 
       var res = {"create": creates, "update": updates, "delete": deletes, "hash": datasetClient.dataHash};
-      var timeTaken = Date.now() - start;
-      apiMetrics.gauge()(apiMetrics.title + '_api_timing', {method: "doSyncRecords"}, timeTaken);
       callback(null, res);
     };
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -157,46 +157,70 @@ function doClientSync(dataset_id, params, callback) {
   function clientSyncImpl() {
 
     DataSetModel.getDatasetClient(dataset_id, params, function (err, datasetClient) {
-      if (err) return callback(err);
 
-      //Deal with any Acknowledgement of updates from the client
+      if (err) {
+        return callback(err);
+      }
+
+      if (datasetClient.dataHash) {
+        /**
+         * In this section we are determining whether the client and the servers
+         * dataset are in sync. If they are then we will no need to do an update,
+         * if they're not we inform the client that they are out of sync.
+         * 
+         * IGNORE: `res` will have a hash appended to it below, if it doesn't somehow it
+         * will be initialised as an empty object in returnUpdates, so we might
+         * as well initialise it here.
+         * 
+         * This section was overcomplicated, the `hash` attribute of datasetClient never
+         * exists, returning datasetHash either way will result in the same behaviour.
+         * 
+         *   * If everything doesn't match the client will update.
+         * 
+         *   * If everything does match the client will be happy.
+         */
+        var hashMatch = (datasetClient.dataHash === params.dataset_hash);
+        syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hash match (' + hashMatch + ')');
+
+        var res = { hash: datasetClient.dataHash };
+      
+        /*if (datasetClient.dataHash === params.dataset_hash) {
+          // There are no pending updates and the client and server are in sync.
+          syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hashes match : (' + datasetClient.dataHash + ', ' + datasetClient.dataHash);
+          res.hash = datasetClient.dataHash;
+        } else {
+          // There are no pending updates and the client and server are not in sync.
+          syncUtil.doLog(dataset_id, 'info', 'doClientSync : Hashes do not match');  
+          res.hash = datasetClient.dataHash; 
+        }*/
+        
+        returnUpdates(dataset_id, params, res, callback);
+      } else {
+        // There is currently no dataset here. We should get it from the backend.
+        syncUtil.doLog(dataset_id, 'info', 'doClientSync : No cloud data set');
+        DataSetModel.syncDatasetClient(datasetClient, function (err, res) {
+          if (err) {
+            return callback(err);
+          }
+          returnUpdates(dataset_id, params, res, callback);
+        });
+      }
+
+      // Remove any `{datasetName}-updates` entries that have been acknowledged by the client.
       acknowledgeUpdates(dataset_id, params, function () {
         if (params.pending && params.pending.length > 0) {
           syncUtil.doLog(dataset_id, 'info', 'Found ' + params.pending.length + ' pending records. processing', params);
 
-          // Process Pending Params then re-sync data
+          // Process any pending records and then re-sync the data.
           processPending(dataset_id, dataset, params, function () {
             syncUtil.doLog(dataset_id, 'verbose', 'back from processPending', params);
             // Changes have been submitted from client, redo the list operation on back end system.
-            DataSetModel.syncDatasetClient(datasetClient, function (err, res) {
-              if (err) return callback(err);
-              var resOut = {"hash": res.hash};
-              return returnUpdates(dataset_id, params, resOut, callback);
+            DataSetModel.syncDatasetClient(datasetClient, function (err) {
+              if (err) {
+                return callback(err);
+              }
             });
           });
-        }
-        else {
-          if (datasetClient.dataHash) {
-            // No pending updates, just sync client dataset
-            //syncUtil.doLog(dataset_id, 'verbose', 'doClientSync - No pending - Hash (Client :: Cloud) = ' + params.dataset_hash + ' :: ' + datasetClient.dataHash, params);
-            var res;
-            if (datasetClient.dataHash === params.dataset_hash) {
-              syncUtil.doLog(dataset_id, 'verbose', 'doClientSync - No pending - Hashes match. Just return hash', params);
-              res = {"hash": datasetClient.hash};
-              return returnUpdates(dataset_id, params, res, callback);
-            }
-            else {
-              syncUtil.doLog(dataset_id, 'info', 'doClientSync - No pending - Hashes NO NOT match (Client :: Cloud) = ' + params.dataset_hash + ' :: ' + datasetClient.dataHash + ' - return cloud hash to trigger partial dataset', params);
-              res = {hash: datasetClient.dataHash};
-              return returnUpdates(dataset_id, params, res, callback);
-            }
-          } else {
-            syncUtil.doLog(dataset_id, 'info', 'No pending records. No cloud data set - invoking list on back end system', params);
-            DataSetModel.syncDatasetClient(datasetClient, function (err, res) {
-              if (err) return callback(err);
-              return returnUpdates(dataset_id, params, res, callback);
-            });
-          }
         }
       });
     });
@@ -418,6 +442,7 @@ function returnUpdates(dataset_id, params, resIn, cb) {
     }
 
     if (!resIn) {
+      console.log('Creating resIn');
       syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - initialising res', params);
       resIn = {};
     }

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -1,4 +1,5 @@
 var crypto = require('crypto');
+var apiMetrics = require('./util/metrics');
 var winston = require('winston');
 var moment = require('moment');
 var assert = require('assert');
@@ -7,6 +8,8 @@ var SYNC_LOGGER = 'SYNC';
 var loggers = {};
 
 var generateHash = function (plainText) {
+  var generateHashStart = Date.now();
+
   var hash;
   if (plainText) {
     if ('string' !== typeof plainText) {
@@ -16,6 +19,8 @@ var generateHash = function (plainText) {
     shasum.update(plainText);
     hash = shasum.digest('hex');
   }
+  apiMetrics.sendTimeDifference({module: 'sync-util', method: 'generateHash'}, generateHashStart);
+  
   return hash;
 }
 
@@ -38,6 +43,8 @@ var sortObject = function (object) {
 
 
 var sortedStringify = function (obj) {
+  var sortedStringifyStart = Date.now();
+
   var str = '';
   try {
     if (obj) {
@@ -45,8 +52,10 @@ var sortedStringify = function (obj) {
     }
   } catch (e) {
     doLog(SYNC_LOGGER, 'error', 'Error stringifying sorted object:' + e);
+    apiMetrics.sendTimeDifference({module: 'sync-util', method: 'sortedStringify'}, sortedStringifyStart, true);
     throw e;
   }
+  apiMetrics.sendTimeDifference({module: 'sync-util', method: 'sortedStringify'}, sortedStringifyStart);
 
   return str;
 }

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -8,7 +8,7 @@ var SYNC_LOGGER = 'SYNC';
 var loggers = {};
 
 var generateHash = function (plainText) {
-  var generateHashStart = Date.now();
+  //var generateHashStart = Date.now();
 
   var hash;
   if (plainText) {
@@ -19,7 +19,7 @@ var generateHash = function (plainText) {
     shasum.update(plainText);
     hash = shasum.digest('hex');
   }
-  apiMetrics.sendTimeDifference({module: 'sync-util', method: 'generateHash'}, generateHashStart);
+  //apiMetrics.sendTimeDifference({module: 'sync-util', method: 'generateHash'}, generateHashStart);
   
   return hash;
 }
@@ -43,7 +43,7 @@ var sortObject = function (object) {
 
 
 var sortedStringify = function (obj) {
-  var sortedStringifyStart = Date.now();
+  //var sortedStringifyStart = Date.now();
 
   var str = '';
   try {
@@ -55,7 +55,7 @@ var sortedStringify = function (obj) {
     apiMetrics.sendTimeDifference({module: 'sync-util', method: 'sortedStringify'}, sortedStringifyStart, true);
     throw e;
   }
-  apiMetrics.sendTimeDifference({module: 'sync-util', method: 'sortedStringify'}, sortedStringifyStart);
+  //apiMetrics.sendTimeDifference({module: 'sync-util', method: 'sortedStringify'}, sortedStringifyStart);
 
   return str;
 }

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -47,5 +47,24 @@ module.exports = {
     }
     return emptyFunction;
   },
-  middleware: middleware
+  middleware: middleware,
+  getTimedCallback: function(tags, originalCallback) {
+    var title = APP_TITLE + '_api_timing';
+
+    var startTime = Date.now();
+
+    return function timeWrappedCallback() {
+      var timeTaken = Date.now() - startTime;
+
+      var result = 'success';
+      // Assuming first value is always `err`
+      if(arguments[0]) result = 'error';
+      tags.result = result;
+
+      if(metrics) metrics.gauge(title, tags, timeTaken);
+      
+      // Call original callback with arguments.
+      return originalCallback.apply(this, arguments);
+    }
+  }
 };

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -4,7 +4,8 @@ var APP_TITLE = "cloud-app-" + process.env.FH_TITLE;
 var config = {
   "enabled": !!process.env.METRICS_HOST,
   "host": process.env.METRICS_HOST,
-  "port": process.env.METRICS_PORT
+  "port": process.env.METRICS_PORT,
+  "syncQueueConcurrency": 100
 };
 
 var middleware;

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -66,5 +66,15 @@ module.exports = {
       // Call original callback with arguments.
       return originalCallback.apply(this, arguments);
     }
+  },
+  sendTimeDifference: function(tags, startTime, error) {
+    var title = APP_TITLE + '_api_timing';
+    var result = 'success';
+    if(error) {
+      result = 'error';
+    }
+
+    var timeTaken = Date.now() - startTime;
+    metrics.gauge(title, tags, timeTaken);
   }
 };

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -5,7 +5,7 @@ var config = {
   "enabled": !!process.env.METRICS_HOST,
   "host": process.env.METRICS_HOST,
   "port": process.env.METRICS_PORT,
-  "syncQueueConcurrency": 100
+  "syncQueueConcurrency": 10
 };
 
 var middleware;
@@ -13,11 +13,11 @@ var metrics;
 if(config && config.enabled){
   console.log("Metrics service enabled " + config.host);
   var metricsObj = fhComponentMetrics(config);
-  metricsObj.memory(APP_TITLE, {interval: 2000}, function(err){
+  metricsObj.memory(APP_TITLE, {interval: 4000}, function(err){
     if(err) console.error(err);
   });
   
-  metricsObj.cpu(APP_TITLE, {interval: 2000}, function(err){
+  metricsObj.cpu(APP_TITLE, {interval: 4000}, function(err){
     if(err) console.error(err);
   });
   middleware = fhComponentMetrics.timingMiddleware(APP_TITLE, config)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "6.1.3",
   "dependencies": {
     "fh-component-metrics": {
-      "version": "2.3.0",
-      "from": "aidenkeating/fh-component-metrics#add_configurable_send_queue_concurrency",
-      "resolved": "git://github.com/aidenkeating/fh-component-metrics.git#2208a0d60374d50bd12f6850a3b81e84a194490b",
+      "version": "2.4.0",
+      "from": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.4.0.tgz",
       "dependencies": {
         "async": {
           "version": "2.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "6.1.3",
   "dependencies": {
     "fh-component-metrics": {
-      "version": "2.2.1",
-      "from": "fh-component-metrics@*",
-      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.2.1.tgz",
+      "version": "2.3.0",
+      "from": "aidenkeating/fh-component-metrics#add_configurable_send_queue_concurrency",
+      "resolved": "git://github.com/aidenkeating/fh-component-metrics.git#2208a0d60374d50bd12f6850a3b81e84a194490b",
       "dependencies": {
         "async": {
           "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "colors": "0.6.2",
     "cycle": "1.0.3",
     "eyes": "0.1.8",
-    "fh-component-metrics": "^2.2.1",
+    "fh-component-metrics": "aidenkeating/fh-component-metrics#add_configurable_send_queue_concurrency",
     "fh-db": "1.2.5",
     "fh-mbaas-client": "0.15.0",
     "fh-mbaas-express": "5.6.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "colors": "0.6.2",
     "cycle": "1.0.3",
     "eyes": "0.1.8",
-    "fh-component-metrics": "aidenkeating/fh-component-metrics#add_configurable_send_queue_concurrency",
+    "fh-component-metrics": "2.4.0",
     "fh-db": "1.2.5",
     "fh-mbaas-client": "0.15.0",
     "fh-mbaas-express": "5.6.6",


### PR DESCRIPTION
This adds time monitoring to many of the functions in fh-mbaas-api.

The monitoring sorted each record by `module` and usually by method
name or by a description in the value for the `method` key of the
record.

I don't know if it makes sense to merge this into the current `monitoring` branch or not. Just adding a PR here for review purposes.

@david-martin @wtrocki Could you take a look please?